### PR TITLE
Fix radiation shielding data for Voltaic 1.0.10+

### DIFF
--- a/src/main/resources/data/voltaic/radiation/cs_radiation_shielding.json
+++ b/src/main/resources/data/voltaic/radiation/cs_radiation_shielding.json
@@ -1,26 +1,26 @@
 {
   "chemicalscience:block_tungsten": {
-    "amount": 2000.0,
-    "level": 1.0
+    "level": 1.0,
+    "transmission": 0.2
   },
   "chemicalscience:block_platinum": {
-    "amount": 2000.0,
-    "level": 1.0
+    "level": 1.0,
+    "transmission": 0.2
   },
   "chemicalscience:radiationshielding_concrete": {
-    "amount": 2500.0,
-    "level": 1.0
+    "level": 1.0,
+    "transmission": 0.1
   },
   "chemicalscience:radiationshielding_tantalum": {
-    "amount": 300000.0,
-    "level": 1.0
+    "level": 1.0,
+    "transmission": 0.0
   },
   "chemicalscience:radiationshielding_glass": {
-    "amount": 25000.0,
-    "level": 1.0
+    "level": 1.0,
+    "transmission": 0.05
   },
   "chemicalscience:radiationshielding_advancedglass": {
-    "amount": 100000.0,
-    "level": 1.0
+    "level": 1.0,
+    "transmission": 0.01
   }
 }


### PR DESCRIPTION
Voltaic 1.0.10 reworked radiation shielding and changed the json format under data/voltaic/radiation from amount/level to transmission/level (transmission is the fraction of radiation that passes through a block, 0.0 blocks everything). Its loader decodes every entry with getOrThrow(), so old-format entries abort the whole datapack load. Any server or singleplayer world running Chemical Science 3.1.1 together with Voltaic 1.0.10 or newer fails to start with:

```
Failed to load datapacks, can't proceed with server load
...
IllegalStateException: No key transmission in MapLike[{"amount":2000.0,"level":1.0}]
```

This converts cs_radiation_shielding.json to the new format. Values are anchored to how the sibling mods translated theirs in their matching updates (Nuclear Science 0.8.6: full shielding block 20000 -> 0.0, shielding glass 5000 -> 0.1; Electrodynamics 1.0.11: lead storage blocks 20000 -> 0.05):

| block | old amount | new transmission |
| --- | --- | --- |
| block_tungsten / block_platinum | 2000 | 0.2 |
| radiationshielding_concrete | 2500 | 0.1 |
| radiationshielding_glass | 25000 | 0.05 |
| radiationshielding_advancedglass | 100000 | 0.01 |
| radiationshielding_tantalum | 300000 | 0.0 |

Feel free to retune the numbers, the important part is the key rename. cs_radioactive_items.json is unaffected since the RadioactiveObject codec did not change in 1.0.10.

Tested on a NeoForge 21.1.193 dedicated server with Voltaic 1.21.1-1.0.10, Electrodynamics 1.21.1-1.0.11 and Chemical Science 1.21.1-3.1.1: without this change the server crashes on startup as above, with it the server boots clean.